### PR TITLE
feat: terminal UI redesign

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { getAllBlogPosts, getBlogPost } from "../blog";
 import { formatDate } from "@/lib/utils";
 import { CustomMDX } from "@/components/mdx";
+import TerminalHeader from "@/components/ui/terminal-header";
 import { Metadata } from "next";
 
 interface IProps {
@@ -18,18 +19,17 @@ export default function Page({ params }: IProps) {
   }
 
   return (
-    <main className="container relative mx-auto scroll-my-12 overflow-auto px-4 py-2 md:mb-12 md:px-16 md:py-4">
-      <section className="mx-auto w-full max-w-2xl space-y-6 bg-white">
+    <main className="mx-auto flex w-full max-w-3xl flex-col items-start p-8 font-mono text-sm">
+      <TerminalHeader cwd="~/blog" />
+      <section className="mt-8 w-full space-y-6">
         <div className="flex-col">
-          <h2 className="text-2xl font-bold leading-tight tracking-tight">
-            {post.metadata.title}
-          </h2>
-          <p className="max-w-md items-center text-pretty py-1 font-mono text-xs text-muted-foreground">
+          <h2 className="text-lg text-foreground">{post.metadata.title}</h2>
+          <p className="text-xs text-gray-500">
             {formatDate(post.metadata.publishedAt)}
           </p>
         </div>
 
-        <article className="prose-md prose dark:prose-invert">
+        <article className="prose-md prose prose-invert">
           <CustomMDX source={post.content} />
         </article>
       </section>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,18 +1,16 @@
 import { getAllBlogPosts } from "@/app/blog/blog";
 import { Section } from "@/components/ui/section";
 import { BlogCard } from "@/components/ui/blog-card";
-import PageTitle from "@/components/ui/page-title";
+import TerminalHeader from "@/components/ui/terminal-header";
 import { Metadata } from "next";
 
 export default function Page() {
   const blogPosts = getAllBlogPosts();
 
   return (
-    <main className="container relative mx-auto scroll-my-12 overflow-auto px-4 py-2 md:mb-12 md:px-16 md:py-4">
-      <section className="mx-auto w-full max-w-2xl space-y-8 bg-white print:space-y-6">
-        <Section>
-          <PageTitle title={"my blog"} />
-        </Section>
+    <main className="mx-auto flex w-full max-w-3xl flex-col items-start p-8 font-mono text-sm">
+      <TerminalHeader cwd="~/blog" />
+      <section className="mt-8 w-full space-y-8">
         <Section>
           {blogPosts.map((blogPost) => (
             <BlogCard

--- a/src/app/bookshelf/all/page.tsx
+++ b/src/app/bookshelf/all/page.tsx
@@ -1,18 +1,18 @@
 import { Section } from "@/components/ui/section";
-import PageTitle from "@/components/ui/page-title";
 import { BookshelfCard } from "@/components/ui/bookshelf-card";
 import { getAllBookshelfItems } from "../bookshelf";
+import TerminalHeader from "@/components/ui/terminal-header";
 import { Metadata } from "next";
 
 export default function Page() {
   const bookshelfItems = getAllBookshelfItems();
 
   return (
-    <main className="container relative mx-auto scroll-my-12 overflow-auto px-4 py-2 md:mb-12 md:px-16 md:py-4">
-      <section className="mx-auto w-full max-w-2xl space-y-8 bg-white print:space-y-6">
+    <main className="mx-auto flex w-full max-w-3xl flex-col items-start p-8 font-mono text-sm">
+      <TerminalHeader cwd="~/bookshelf" />
+      <section className="mt-8 w-full space-y-8">
         <Section>
-          <PageTitle title={"my bookshelf"} />
-          <p className="text-pretty font-mono text-sm text-muted-foreground">
+          <p className="text-foreground">
             {
               "if my blog came up short, then look no further! here are the best things I have found on the internet, made by people much smarter than me."
             }

--- a/src/app/bookshelf/page.tsx
+++ b/src/app/bookshelf/page.tsx
@@ -1,18 +1,18 @@
 import { Section } from "@/components/ui/section";
-import PageTitle from "@/components/ui/page-title";
 import { BookshelfCard } from "@/components/ui/bookshelf-card";
 import { getAllBookshelfItems } from "./bookshelf";
+import TerminalHeader from "@/components/ui/terminal-header";
 import { Metadata } from "next";
 
 export default function Page() {
   const bookshelfItems = getAllBookshelfItems();
 
   return (
-    <main className="container relative mx-auto scroll-my-12 overflow-auto px-4 py-2 md:mb-12 md:px-16 md:py-4">
-      <section className="mx-auto w-full max-w-2xl space-y-8 bg-white print:space-y-6">
+    <main className="mx-auto flex w-full max-w-3xl flex-col items-start p-8 font-mono text-sm">
+      <TerminalHeader cwd="~/bookshelf" />
+      <section className="mt-8 w-full space-y-8">
         <Section>
-          <PageTitle title={"my bookshelf"} />
-          <p className="text-pretty font-mono text-sm text-muted-foreground">
+          <p className="text-foreground">
             {
               "if my blog came up short, then look no further! here are the best things I have found on the internet, made by people much smarter than me."
             }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,33 +4,33 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 224 71.4% 4.1%;
+    --background: 0 0% 13%;
+    --foreground: 0 0% 90%;
 
-    --card: 0 0% 100%;
-    --card-foreground: 224 71.4% 4.1%;
+    --card: 0 0% 18%;
+    --card-foreground: 0 0% 90%;
 
-    --popover: 0 0% 100%;
-    --popover-foreground: 224 71.4% 4.1%;
+    --popover: 0 0% 18%;
+    --popover-foreground: 0 0% 90%;
 
-    --primary: 220.9 39.3% 11%;
-    --primary-foreground: 210 20% 98%;
+    --primary: 0 0% 90%;
+    --primary-foreground: 0 0% 13%;
 
-    --secondary: 220 14.3% 95.9%;
-    --secondary-foreground: 220.9 39.3% 11%;
+    --secondary: 0 0% 20%;
+    --secondary-foreground: 0 0% 70%;
 
-    --muted: 220 14.3% 95.9%;
-    --muted-foreground: 220 8.9% 46.1%;
+    --muted: 0 0% 20%;
+    --muted-foreground: 0 0% 60%;
 
-    --accent: 220 14.3% 95.9%;
-    --accent-foreground: 220.9 39.3% 11%;
+    --accent: 0 0% 22%;
+    --accent-foreground: 0 0% 90%;
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 20% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 90%;
 
-    --border: 220 13% 91%;
-    --input: 220 13% 91%;
-    --ring: 224 71.4% 4.1%;
+    --border: 0 0% 25%;
+    --input: 0 0% 25%;
+    --ring: 0 0% 60%;
 
     --radius: 0.5rem;
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/react";
 
 import React from "react";
-import Header from "@/components/ui/header";
+import TerminalHeader from "@/components/ui/terminal-header";
 
-import { Inter } from "next/font/google";
+import { JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -12,8 +12,7 @@ export const metadata: Metadata = {
   description: "my personal site",
 };
 
-// If loading a variable font, you don't need to specify the font weight
-const inter = Inter({
+const mono = JetBrains_Mono({
   subsets: ["latin"],
   display: "swap",
 });
@@ -24,9 +23,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={inter.className}>
+    <html lang="en" className={mono.className}>
       <body>
-        <Header />
         {children}
         <Analytics />
       </body>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,14 +1,10 @@
-import { Section } from "@/components/ui/section";
-import PageTitle from "@/components/ui/page-title";
+import TerminalHeader from "@/components/ui/terminal-header";
 
 export default function NotFound() {
   return (
-    <main className="container relative mx-auto scroll-my-12 overflow-auto px-4 py-2 print:p-12 md:px-16 md:py-4">
-      <section className="mx-auto w-full max-w-2xl space-y-8 bg-white print:space-y-6">
-        <Section>
-          <PageTitle title={"404: Not Found"} />
-        </Section>
-      </section>
+    <main className="mx-auto flex w-full max-w-3xl flex-col items-start p-8 font-mono text-sm">
+      <TerminalHeader />
+      <p className="mt-8 text-foreground">bash: 404: command not found</p>
     </main>
   );
 }

--- a/src/components/ui/terminal-header.tsx
+++ b/src/components/ui/terminal-header.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+const NAV_ITEMS = [
+  { name: "blog", href: "/blog" },
+  { name: "bookshelf", href: "/bookshelf" },
+];
+
+function Prompt({ cwd = "~" }: { cwd?: string }) {
+  return (
+    <>
+      <span className="text-blue-400">henry</span>
+      <span className="text-gray-600">@</span>
+      <span className="text-gray-500">mac-mini</span>
+      <span className="text-gray-600">:{cwd}</span>
+      <span className="text-gray-500">&nbsp;$&nbsp;&nbsp;</span>
+    </>
+  );
+}
+
+export default function TerminalHeader({ cwd = "~" }: { cwd?: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="w-full font-mono text-sm">
+      <div className="flex h-6 w-full items-center justify-between">
+        <Link href="/" className="flex items-center hover:underline">
+          <Prompt cwd={cwd} />
+        </Link>
+
+        {/* Desktop nav */}
+        <div className="hidden gap-6 sm:flex">
+          {NAV_ITEMS.map((item) => (
+            <Link
+              key={item.name}
+              href={item.href}
+              className="text-blue-400 hover:underline"
+            >
+              {item.name}
+            </Link>
+          ))}
+        </div>
+
+        {/* Mobile hamburger */}
+        <button
+          onClick={() => setOpen(!open)}
+          className="text-gray-500 hover:text-foreground sm:hidden"
+          aria-label="Toggle menu"
+        >
+          {open ? "[ x ]" : "[ ≡ ]"}
+        </button>
+      </div>
+
+      {/* Mobile dropdown */}
+      {open && (
+        <div className="mt-2 flex flex-col gap-2 sm:hidden">
+          {NAV_ITEMS.map((item) => (
+            <Link
+              key={item.name}
+              href={item.href}
+              className="text-blue-400 hover:underline"
+              onClick={() => setOpen(false)}
+            >
+              {item.name}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -71,10 +71,15 @@ module.exports = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        blink: {
+          "0%, 100%": { opacity: "1" },
+          "50%": { opacity: "0" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        blink: "blink 1s step-end infinite",
       },
     },
   },


### PR DESCRIPTION
Redesigns the site as an AI agent terminal interface.

- Dark terminal background with JetBrains Mono font
- Animated homepage: blinking cursor, types ls for nav,
  types sysinfo for bio with character-by-character output
- Terminal prompt as clickable home button with cwd
- Responsive hamburger menu ([ ≡ ]) on small screens
- Updated blog, bookshelf, and 404 pages to match
- Dark color scheme for cards, badges, and borders