### PR TITLE
fix: remove menu close on nav click

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,15 @@
+export default function Loading() {
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col items-start p-8 font-mono text-sm">
+      <div className="w-full font-mono text-sm">
+        <div className="flex h-6 w-full items-center">
+          <span className="text-blue-400">henry</span>
+          <span className="text-gray-600">@</span>
+          <span className="text-gray-500">mac-mini</span>
+          <span className="text-gray-600">:~</span>
+          <span className="text-gray-500">&nbsp;$&nbsp;&nbsp;</span>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -198,7 +198,6 @@ export default function Page() {
               key={item.name}
               href={item.href}
               className="text-blue-400 hover:underline"
-              onClick={() => setMenuOpen(false)}
             >
               {item.name}
             </Link>


### PR DESCRIPTION
The onClick handler closing the mobile menu before navigation caused a visible content shift. Since navigation unmounts the component, manually closing the menu is unnecessary.