### PR TITLE
chore: auto-merge minor and patch dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add a Renovate `packageRules` entry that enables `automerge` for `minor` and `patch` update types
- Major version bumps continue to require manual review

## Test plan
- [ ] Renovate dashboard/validator accepts the updated `renovate.json`
- [ ] Next minor/patch dependency PR opened by Renovate merges automatically once checks pass
- [ ] Next major-version PR still requires manual approval

https://claude.ai/code/session_011nVukACgzjHxz6fv3TQinb